### PR TITLE
ci(actions): use node-version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,11 @@
 name: Run tests on push
-on: [push, pull_request]
-push:
-  paths:
-    - "*.js"
-pull_request:
-  paths:
-    - "*.js"
+on: 
+  push:
+    paths:
+      - "*.js"
+  pull_request:
+    paths:
+      - "*.js"
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set Node.js 10.x
       uses: actions/setup-node@master
       with:
-        version: 10.x
+        node-version: 10.x
     - name: Install dependencies
       run: npm ci
     - name: Lint


### PR DESCRIPTION
Fixes a deprecation warning from the `setup-node` Action.

Closes #8